### PR TITLE
Handle the `noFile` case properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,15 @@ function getConstants(data, options) {
 function getFilePath(filePath, options) {
     if (!options.dest) {
         return gutil.replaceExtension(filePath, '.js');
+    } else {
+        var parent;
+        if (options.noFile) {
+            parent = process.env.PWD;
+        } else {
+            parent = path.dirname(filePath);
+        }
+        return path.join(parent, options.dest);
     }
-
-    return path.join(path.dirname(filePath), options.dest);
 }
 
 function pluginError(msg) {


### PR DESCRIPTION
The problem is that if the `noFile` flag is on, the `file` object will come with a `null` path thus breaking the logic of `path.dirname` which is not checked at all.

In this solution I provide a fallback
